### PR TITLE
Update MALP link to new location

### DIFF
--- a/content/clients/index.md
+++ b/content/clients/index.md
@@ -49,7 +49,7 @@ featured client.
 
 ## Android
 
-[M.A.L.P.](https://github.com/gateship-one/malp)
+[M.A.L.P.](https://gitlab.com/gateship-one/malp)
 
 [MPDroid](https://github.com/abarisain/dmix)
 


### PR DESCRIPTION
MALP has moved from GitHub to GitLab, this change updates the link to point to the new location.