### PR TITLE
Set `alt` for MPD logo

### DIFF
--- a/layouts/default.html
+++ b/layouts/default.html
@@ -29,7 +29,7 @@
       <%= yield %>
     </div>
     <div id="sidebar">
-      <a href="/"><img src="/logo.png"></img></a>
+      <a href="/"><img src="/logo.png" alt="Music Player Daemon logo"></img></a>
 
       <ul>
         <li><a href="/">News</a></li>


### PR DESCRIPTION
`alt` is used if image fails to load or in screen readers.