### PR TITLE
Switch to bullseye for default release

### DIFF
--- a/content/download-unoff-debian.md
+++ b/content/download-unoff-debian.md
@@ -20,18 +20,18 @@ Then, identify the release your running by its codename running:
 
     lsb_release -sc
 
-Assuming your release is *buster* from now on, add the sources:
+Assuming your release is *bullseye* from now on, add the sources:
 
 for **Debian** (`amd64` only):
 
     # Add this line in /etc/apt/sources.list.d/deb.kaliko.me.list
-    deb [signed-by=/usr/share/keyrings/deb.kaliko.me.gpg] https://deb.kaliko.me/debian-backports/ buster-backports main
+    deb [signed-by=/usr/share/keyrings/deb.kaliko.me.gpg] https://deb.kaliko.me/debian-backports/ bullseye-backports main
 
 
 for **Raspberry Pi OS** (`armhf` only)
 
     # Add this line in /etc/apt/sources.list.d/deb.kaliko.me.list
-    deb [signed-by=/usr/share/keyrings/deb.kaliko.me.gpg] https://deb.kaliko.me/raspios-backports/ buster-backports main
+    deb [signed-by=/usr/share/keyrings/deb.kaliko.me.gpg] https://deb.kaliko.me/raspios-backports/ bullseye-backports main
 
 Now update the package index files with “`apt update`”.  
 
@@ -39,7 +39,7 @@ Now update the package index files with “`apt update`”.
 
 You must explicitly install the package giving the *target_release*:
 
-    apt install mpd/buster-backports
+    apt install mpd/bullseye-backports
 
 For requests or information regarding these repositories please refer to [the website: deb.kaliko.me](https://deb.kaliko.me).
 


### PR DESCRIPTION
Bullseye Raspberry Pi OS images have been officially released (8th Nov 2021).
https://www.raspberrypi.com/news/raspberry-pi-os-debian-bullseye/