### PR TITLE
Update "Client Libraries" python modules

### DIFF
--- a/content/libs/index.md
+++ b/content/libs/index.md
@@ -6,8 +6,8 @@ The following libraries implement the MPD protocol, and may be used to
 implement clients.
 
 - [libmpdclient](libmpdclient/) - for C and C++
-- [python-mpd2](python-mpd2/) - python 2/3 module, a python-mpd fork.
-- [python-musicpd](python-musicpd) - python 3 only, a python-mpd fork.
+- [python-mpd2](python-mpd2/) - python 3 module.
+- [python-musicpd](python-musicpd) - python 3 module.
 - [mpcw.client](https://github.com/20centaurifux/mpcw.client) -  Client library written in Java. It implements only a small subset of the protocol.
 - [haxe-musicpd](haxe-musicpd) - haxe client library
 

--- a/content/libs/python-mpd2.md
+++ b/content/libs/python-mpd2.md
@@ -2,17 +2,17 @@
 title: python-mpd2
 ---
 
-A stable, documented python 2/3 module.
+A stable, documented python 3 module.
 
- * python >=3.2, >=2.6
+ * python >=3.6
  * logging
  * configureable timeouts
 
-python-mpd2 is de facto the current fork of python-mpd which is unmaintained now.
+python-mpd2 is a fork of python-mpd which is unmaintained now.
 
 ## Download
 
-[Source tarballs](https://github.com/Mic92/python-mpd2/releases)
+[Source tarballs](https://github.com/Mic92/python-mpd2/tags)
 
 [git repository](https://github.com/Mic92/python-mpd2)
 

--- a/content/libs/python-musicpd.md
+++ b/content/libs/python-musicpd.md
@@ -2,15 +2,15 @@
 title: python-musicpd
 ---
 
-A python 3 only module. python-musicpd is a port of python-mpd to python3 with no intention to support python2.
+python-musicpd is a port of the now defunct python-mpd to python3.
 
-In comparison with [python-mpd2](../python-mpd2) this module intends to keep things simple (python3 only, no logging), this is a plain evolution of python-mpd.
+In comparison with [python-mpd2](../python-mpd2) this module intends to keep things simple, this is a plain evolution of python-mpd.
 
 ## Download
 
-[Download from PyPI](https://pypi.org/pypi/python-musicpd): pip install python-musicpd
-
-[git repository](http://git.kaliko.me/?p=python-musicpd.git)
+ * [PyPI](https://pypi.org/pypi/python-musicpd): `pip install python-musicpd`
+ * [git](http://git.kaliko.me/?p=python-musicpd.git): `git clone git://git.kaliko.me/python-musicpd.git`
+ * forge: [gitlab.com/kaliko/python-musicpd](https://gitlab.com/kaliko/python-musicpd)
 
 ## Documentation
 


### PR DESCRIPTION
Remove python 2 mentions, not supported anymore in python-mpd2
Update projects links