### PR TITLE
Fixed wrong path for apt keys

### DIFF
--- a/content/download-unoff-debian.md
+++ b/content/download-unoff-debian.md
@@ -12,7 +12,7 @@ Debian and Raspberry Pi OS (previously called Raspbian).
 ### Setting up the repo (as root)
 
 First, get the signing key in apt keyring.  
-Add the [key *0x065FE53932DC551D*](https://media.kaliko.me/kaliko.gpg) to `/etc/apt/trusted.gpg.d/` :
+Add the [key *0x065FE53932DC551D*](https://media.kaliko.me/kaliko.gpg) to `/usr/share/keyrings/` :
 
     wget -O /usr/share/keyrings/deb.kaliko.me.gpg https://media.kaliko.me/kaliko.gpg
 


### PR DESCRIPTION
Fixed apt key location to be consistent with wget command:  
`/etc/apt/trusted.gpg.d/` → `/usr/share/keyrings/`