### PR TITLE
Fix href link to edit the current list of clients

### DIFF
--- a/content/clients/index.md
+++ b/content/clients/index.md
@@ -126,4 +126,4 @@ At the writing time - more recent, compared to some other gtk clients.
 ## More
 
 There are many more clients.  Please help and
-[add them to this list](https://github.com/MusicPlayerDaemon/website).
+[add them to this list](https://github.com/MusicPlayerDaemon/website/blob/master/content/clients/index.md).


### PR DESCRIPTION
The current link only points to MPD's website on github, not the actual page where to make the changes.