### PR TITLE
Add inori to console clients list

### DIFF
--- a/content/clients/index.md
+++ b/content/clients/index.md
@@ -35,6 +35,8 @@ written in Go with vi-like interface.
 
 [mpq](https://github.com/codesoap/mpq) - A minimal client that focuses on the mpd queue
 
+[inori](https://github.com/eshrh/inori) - Client with a folding library view, queue interface, and effective fuzzy searching
+
 ## Utility clients
 
 [MPD_sima](https://kaliko.me/mpd-sima/) - A non-interactive autoqueue client. It will queue new tracks following last.fm similar artists suggestions.


### PR DESCRIPTION
I recently wrote a new terminal mpd client, [inori](https://github.com/eshrh/inori), which I think is ready for general use; I've just published the first version and uploaded it to cargo and the Arch AUR. The primary unique contributions are fast fuzzy (unicode aware) searching everywhere, to help with non-latin scripts; and a pretty folding cmus-style library view.