### PR TITLE
Update clients Cantata, QMPDClient, MAENMPC. Add erlmpd library.

### DIFF
--- a/content/clients/index.md
+++ b/content/clients/index.md
@@ -37,6 +37,8 @@ written in Go with vi-like interface.
 
 [inori](https://github.com/eshrh/inori) - Client with a folding library view, queue interface, and effective fuzzy searching
 
+[MAENMPC](https://masysma.net/32/maenmpc.xhtml) - Experimental MPD client with stars-based ratings, play counts and radio-inspired playlist generation
+
 ## Utility clients
 
 [MPD_sima](https://kaliko.me/mpd-sima/) - A non-interactive autoqueue client. It will queue new tracks following last.fm similar artists suggestions.

--- a/content/clients/index.md
+++ b/content/clients/index.md
@@ -73,6 +73,8 @@ written in Go with vi-like interface.
 
 ## Graphical Clients
 
+[Cantata](https://github.com/nullobsi/cantata) - A Qt client.
+
 [CoverGrid](https://www.suruatoel.xyz/codes/mcg) - A client for the Music Player Daemon (MPD), focusing on albums instead of single tracks
 
 [MMC4W](https://github.com/drgerg/mmc4w) - A tiny Windows client built with Tkinter. Minimal yet capable. Supports embedded art.
@@ -129,12 +131,10 @@ written in Go with vi-like interface.
 
 [ario](http://ario-player.sourceforge.net/) - Another GTK based client.
 
-[Cantata](https://github.com/cdrummond/cantata) - A Qt client.
-
 [gmpc](http://gmpclient.org/)(Gnome Music Player Client) - A fully
 featured client.
 
-[QMPDClient](http://bitcheese.net/QMPDClient/) - Qt4 based mpd client, originally developed by Håvard Tautra Knutsen. Set of patches developed by community was then called "QMPDClient-ne". Now it became mainline
+[QMPDClient](https://gitlab.com/Voker57/qmpdclient) - Qt4 based mpd client, originally developed by Håvard Tautra Knutsen. Set of patches developed by community was then called "QMPDClient-ne". Now it became mainline
 
 [Sonata](https://github.com/multani/sonata) - Client, now ported to Gtk3.
 At the writing time - more recent, compared to some other gtk clients.

--- a/content/libs/index.md
+++ b/content/libs/index.md
@@ -13,6 +13,7 @@ implement clients.
 - [simple-php-mpd-client](https://packagist.org/packages/kolbasyatin/php-mpd-client) - a small php library lets you control MPD inside your PHP application.
 - [MphpD](https://github.com/FloFaber/MphpD) - A fully-featured, dependency-free PHP library for MPD.
 - [libmpd-haskell](https://hackage.haskell.org/package/libmpd) - Native Haskell library for MPD.
+- [erlmpd](https://masysma.net/32/erlmpd.xhtml) - Pure Erlang client library for the MPD protocol.
 
 There are many more client libraries.  Please help and
 [add them to this list](https://github.com/MusicPlayerDaemon/website).


### PR DESCRIPTION
I was about to add my own client MAENMPC and my fork of the client library erlmpd to the list of clients. In noticed some of the client information were out of date and attempted to update them along the way. Effectively, I propose the following changes:

 * [clients: Update links for Cantata and QMPDClient](https://github.com/MusicPlayerDaemon/website/commit/9055efac7ca4c7e36e339bdf95992c8b45ff3336)
 * [libs: Add erlmpd, an MPD client library for Erlang](https://github.com/MusicPlayerDaemon/website/commit/3a07ab782fd792bc88c16b0827cb26d38d5a4798)
 * [clients: Add MAENMPC, a new and experimental console-based MPD client](https://github.com/MusicPlayerDaemon/website/commit/86eb1af9dc58ab82d97371ea3dc31aaa3889ddb0)

Thanks in advance and Kind regards
Linux-Fan (@m7a)