### PR TITLE
Added a JavaScript client library to the list. 

### DIFF
--- a/content/libs/index.md
+++ b/content/libs/index.md
@@ -14,6 +14,7 @@ implement clients.
 - [MphpD](https://github.com/FloFaber/MphpD) - A fully-featured, dependency-free PHP library for MPD.
 - [libmpd-haskell](https://hackage.haskell.org/package/libmpd) - Native Haskell library for MPD.
 - [erlmpd](https://masysma.net/32/erlmpd.xhtml) - Pure Erlang client library for the MPD protocol.
+- [mpc.js](https://github.com/hbenl/mpc-js-core) - A Comprehensive Promise-based JavaScript client library.
 
 There are many more client libraries.  Please help and
 [add them to this list](https://github.com/MusicPlayerDaemon/website).

--- a/content/libs/index.md
+++ b/content/libs/index.md
@@ -17,4 +17,4 @@ implement clients.
 - [mpc.js](https://github.com/hbenl/mpc-js-core) - A Comprehensive Promise-based JavaScript client library.
 
 There are many more client libraries.  Please help and
-[add them to this list](https://github.com/MusicPlayerDaemon/website).
+[add them to this list](https://github.com/MusicPlayerDaemon/website/blob/master/content/libs/index.md).


### PR DESCRIPTION
Also fixed the "There are many more client libraries. Please help and add them to this list." 

Current behavior: The hyperlink points to the root of GitHub repo.

Updated behavior: The hyperlink points to the page on GitHub, which corresponds to "client libraries" page.