### PR TITLE
clients: add mpDris2, a client adding MPRIS 2 support

### DIFF
--- a/content/clients/index.md
+++ b/content/clients/index.md
@@ -47,6 +47,8 @@ written in Go with vi-like interface.
 
 [bmp](https://github.com/matm/bmp) - Best music parts tracker for MPD
 
+[mpDris2](https://github.com/eonpatapon/mpDris2) - MPRIS 2 support, for media keys, notifications, and other system music player integrations.
+
 ## Web Clients
 
 [netjukebox](http://www.netjukebox.nl/) the flexible media share - netjukebox is a web-based media jukebox for MPD, VideoLAN and Winamp/httpQ.


### PR DESCRIPTION
Add mpDris2 client, which connects to MPD and announces it over MPRIS 2, for integration with media keys, notifications, and things like desktop environments' media player widgets