### PR TITLE
client: added ps-mpd, a Powershell module client

### DIFF
--- a/content/clients/index.md
+++ b/content/clients/index.md
@@ -15,6 +15,8 @@ This is an (incomplete) list of free and open source MPD clients.
 [mpc](mpc/) - a solid, lightweight, simple mpd client,
 written in C.
 
+[ps-mpd](https://github.com/insomnimus/ps-mpd) an MPD client as a Powershell (v7+) module, allowing programmatic, structured access to songs, albums and artists as well as playback controls.
+
 ## Console Clients
 
 [ncmpc](ncmpc/) - A curses client written in C++.


### PR DESCRIPTION
I maintain [ps-mpd](https://github.com/insomnimus/ps-mpd), a Powershell module that acts as a command line client for MPD.

Along with serving the same purpose as mpc, this client has some unique features: Since Powershell is structured (or object-oriented), this client also lets you access your music library programmatically. You can e.g. easily export your playlists into a JSON file, maybe to import somewhere else by artist / album / song titles.

It has existed for years, and I use it exclusively so it's a capable, stable client, albeit a little niche.
