### PR TITLE
Added JavaScript client library to the list of client libraries.

### DIFF
--- a/content/libs/index.md
+++ b/content/libs/index.md
@@ -15,6 +15,7 @@ implement clients.
 - [libmpd-haskell](https://hackage.haskell.org/package/libmpd) - Native Haskell library for MPD.
 - [erlmpd](https://masysma.net/32/erlmpd.xhtml) - Pure Erlang client library for the MPD protocol.
 - [Simple.MPD](https://github.com/RafaelEstevamReis/SimpleMPD) - a small, dependency-free C# library for MPD.
+- [mpc-js](https://github.com/hbenl/mpc-js) - A Comprehensive Promise-based JavaScript client library.
 
 There are many more client libraries.  Please help and
-[add them to this list](https://github.com/MusicPlayerDaemon/website).
+[add them to this list](https://github.com/bedro0/MPDWebsite/blob/master/content/libs/index.md).


### PR DESCRIPTION
Additionally, fixed the "add them to this list" link, which used to point to the root of the repo. Now it points to client libraries page.