### PR TITLE
MPDroid doesn't work on new phones

### DIFF
--- a/content/clients/index.md
+++ b/content/clients/index.md
@@ -121,8 +121,6 @@ written in Go with vi-like interface.
 
 [M.A.L.P.](https://gitlab.com/gateship-one/malp) - A mpd client for Android
 
-[MPDroid](https://github.com/abarisain/dmix) - A modern MPD Client for Android
-
 ## Wear OS
 
 [MPC Wear](https://github.com/20centaurifux/mpcw) - A MPD Client for Wear OS
@@ -154,6 +152,8 @@ featured client.
 
 [Sonata](https://github.com/multani/sonata) - Client, now ported to Gtk3.
 At the writing time - more recent, compared to some other gtk clients.
+
+[MPDroid](https://github.com/abarisain/dmix) - A modern MPD Client for Android, no longer runs on new versions of Android
 
 ## More
 


### PR DESCRIPTION
I moved it to the unmaintained section because the author said in 2018 that it is unmaintained: abarisain/dmix#856 (comment)

The app has been working, but it can't be installed on phones with newer processors (side loading the APK gives the generic You can't install the app on your device error, and F-Droid doesn't offer it for installation). On older phones, it mostly works but has some significant bugs.

The last work on the repository was 4 years ago and there are 150+ issues open. Several of those issues are about the major work that would be needed to make the app compatible with newer Android devices/OS versions. It is clearly not going to happen.

This is a repeat of #141 - I never got a notification and it looks like the PR can't be reopened.