### PR TITLE
clients: rename the mpDris2 asyncio fork entry to mpd2mpris

### DIFF
--- a/content/clients/index.md
+++ b/content/clients/index.md
@@ -55,9 +55,9 @@ written in Go with vi-like interface.
 
 [mpd-discplayer](https://github.com/b0bbywan/go-mpd-discplayer) - A Go client that automates audio CD and removable USB media playback on MPD, generating CUE files and cover art for discs.
 
-[mpDris2](https://github.com/eonpatapon/mpDris2) - MPRIS 2 support, for media keys, notifications, and other system music player integrations.
+[mpd2mpris](https://github.com/b0bbywan/mpd2mpris) - An asyncio MPRIS 2 bridge for MPD with enhanced cover art support, from the MPD `readpicture`/`albumart` commands to remote sources for tagged albums and web radios.
 
-[mpDris2 (asyncio fork)](https://github.com/b0bbywan/mpDris2) - An asyncio-based fork of mpDris2 with enhanced cover art support, from the MPD `readpicture`/`albumart` commands to remote sources for tagged albums and web radios.
+[mpDris2](https://github.com/eonpatapon/mpDris2) - MPRIS 2 support, for media keys, notifications, and other system music player integrations.
 
 [BGM-MPD](https://git.sr.ht/~nytpu/bgm-mpd) - Play music with gaps between tracks, in the style of ambient video game background music
 


### PR DESCRIPTION
The b0bbywan asyncio fork was renamed mpDris2 -> mpd2mpris (https://github.com/b0bbywan/mpd2mpris), in agreement with eonpatapon, the original mpDris2 maintainer, to avoid confusion between the two projects. Describe the entry standalone (no longer "an asyncio fork of mpDris2") and place it next to the other b0bbywan client.